### PR TITLE
Add names to character colliders, for better collision or intersection indication

### DIFF
--- a/example/CharacterModel.tsx
+++ b/example/CharacterModel.tsx
@@ -212,11 +212,7 @@ export default function CharacterModel(props: CharacterModelProps) {
 
       {/* Replace yours model here */}
       {/* Head collider */}
-      <BallCollider
-        name="character-head-ball-collider"
-        args={[0.5]}
-        position={[0, 0.45, 0]}
-      />
+      <BallCollider args={[0.5]} position={[0, 0.45, 0]} />
       {/* Right hand collider */}
       <mesh ref={rightHandRef} />
       <BallCollider

--- a/example/CharacterModel.tsx
+++ b/example/CharacterModel.tsx
@@ -212,7 +212,11 @@ export default function CharacterModel(props: CharacterModelProps) {
 
       {/* Replace yours model here */}
       {/* Head collider */}
-      <BallCollider args={[0.5]} position={[0, 0.45, 0]} />
+      <BallCollider
+        name="character-head-ball-collider"
+        args={[0.5]}
+        position={[0, 0.45, 0]}
+      />
       {/* Right hand collider */}
       <mesh ref={rightHandRef} />
       <BallCollider

--- a/src/Ecctrl.tsx
+++ b/src/Ecctrl.tsx
@@ -1153,7 +1153,7 @@ const Ecctrl = forwardRef<RapierRigidBody, EcctrlProps>(({
       {...props}
     >
       <CapsuleCollider
-        name="character-body-capsule-collider"
+        name="character-capsule-collider"
         args={[capsuleHalfHeight, capsuleRadius]} 
       />
       <group ref={characterModelRef} userData={{ camExcludeCollision: true }}>

--- a/src/Ecctrl.tsx
+++ b/src/Ecctrl.tsx
@@ -1152,7 +1152,10 @@ const Ecctrl = forwardRef<RapierRigidBody, EcctrlProps>(({
       friction={props.friction || -0.5}
       {...props}
     >
-      <CapsuleCollider args={[capsuleHalfHeight, capsuleRadius]} />
+      <CapsuleCollider
+        name="character-body-capsule-collider"
+        args={[capsuleHalfHeight, capsuleRadius]} 
+      />
       <group ref={characterModelRef} userData={{ camExcludeCollision: true }}>
         {/* This mesh is used for positioning the slope ray origin */}
         <mesh


### PR DESCRIPTION
I was recently using a cuboidCollider with `onIntersectionEnter` and exit. I found the character to trigger the event more than once on each enter/exit. Because it has colliders on the model, and on the Ecctrl component itself. By adding a `name` property to each one, especially the Ecctrl one, we can now detect or differentiate exactly which one caused the event to fire. So if we want to detect a single event, we can exclude those that don't have the `character-body-capsule-collider` name, for example.

These names would show up in `onIntersectionEnter` > `event.colliderObject.name`